### PR TITLE
chore: bump version to 1.4.1 and fix npm publish workflow

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
       - run: npm ci --ignore-scripts
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci --ignore-scripts
       - run: npm publish

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alfred-jira-issue-list",
   "type": "module",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "description": "JIRA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
This PR fixes two issues to enable successful npm publishing:

1. **Version bump**: Updates package.json from 1.3.2 to 1.4.1
2. **Fix publish workflow**: Updates npmpublish.yml to use Node 20 instead of Node 16

## Why These Changes?

The v1.4.0 tag was created but the npm publish failed because:
- ❌ package.json still showed version 1.3.2 (should have been 1.4.0)
- ❌ The npmpublish workflow was using Node 16, but alfy@3.0.0 requires Node >=20

## Changes Made

- Bump version to 1.4.1 in package.json
- Update npmpublish.yml workflow to use Node 20 (both build and publish jobs)

## After Merge

Once this is merged, you'll need to:
1. Create a new GitHub release for v1.4.1
2. The GitHub action will automatically publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)